### PR TITLE
@ashfurrow -> fix crash if attributes count is zero

### DIFF
--- a/ARCollectionViewMasonryLayout.m
+++ b/ARCollectionViewMasonryLayout.m
@@ -310,7 +310,7 @@
 {
     NSArray *attributes = self.attributesGrid.allItemAttributes;
     // This can happen during a reload, returning nil is no problem.
-    if (path.row > attributes.count - 1) return nil;
+    if (path.row + 1 > attributes.count) return nil;
     return attributes[path.row];
 }
 


### PR DESCRIPTION
If there are no attributes, `attributes.count - 1` becomes a big number because it is unsigned. Our test to prevent accessing an invalid array index then does not work as expected and can result in a crash.
